### PR TITLE
#bugfix - lf-ng-md-file-input.js:389 Uncaught TypeError: Cannot read property 'files' of undefined

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -33,8 +33,6 @@
   "homepage": "https://github.com/shuyu/angular-material-fileinput",
   "main": [
     "./dist/lf-ng-md-file-input.css",
-    "./dist/lf-ng-md-file-input.min.css",
-    "./dist/lf-ng-md-file-input.js",
-    "./dist/lf-ng-md-file-input.min.js"
+    "./dist/lf-ng-md-file-input.js"
   ]
 }

--- a/src/lf-ng-md-file-input.js
+++ b/src/lf-ng-md-file-input.js
@@ -386,6 +386,8 @@
 
 					elDragview.removeClass("lf-ng-md-file-input-drag-hover");
 
+                    e.dataTransfer = e.originalEvent.dataTransfer;
+
 					var files = e.target.files || e.dataTransfer.files;
 					var i = 0;
 					var file;


### PR DESCRIPTION
A fix for jQuery event model hack -
http://stackoverflow.com/questions/7640234/jquery-ui-draggable-droppable
-datatransfer-is-undefined