### PR TITLE
mozilla file input click fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 node_modules/
 .sass-cache
 *.log

--- a/src/lf-ng-md-file-input.js
+++ b/src/lf-ng-md-file-input.js
@@ -439,7 +439,7 @@
 						$timeout(function() {
 							event.preventDefault();
 							event.stopPropagation();
-							var elFileinput = event.target.children[2];
+							var elFileinput = angular.element(event.target).querySelector('input[type=file]');
 							if(elFileinput !== undefined) {
 								elFileinput.click();
 							}


### PR DESCRIPTION
file input click was not working in some mozilla browser versions, because of the selector that had been changed changed by current commit that was previously returning not the file input but an 'md-errors-spacer'