### PR TITLE
Code hardening to deal with null/undefined files object

### DIFF
--- a/dist/lf-ng-md-file-input.js
+++ b/dist/lf-ng-md-file-input.js
@@ -598,7 +598,7 @@
                 });
 
                 var onFileChanged = function(files) {
-					if(files.length <= 0){
+					if(files.length <= 0 || !scope.lfFiles || !scope.lfFiles.map){ //Check for scope.lfFiles.map needed because if file is set to NULL, map doesn't exist
 						return;
 					}
                     var names = scope.lfFiles.map(function(obj){


### PR DESCRIPTION
As part of a form reset, I had set my bound files object to be null. This code assumed files to be a valid array (which would then have .map() on it) so I added logic to short-circuit onFileChanged() if files is null/undefined or doesn't have .map on it.